### PR TITLE
[WIP] Numba

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy
 scipy
+numba

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 scipy
 numba
+gudhi

--- a/src/permaviss/persistence_algebra/PH_classic.py
+++ b/src/permaviss/persistence_algebra/PH_classic.py
@@ -11,7 +11,7 @@ from numba import njit
 from numba import types
 from numba.cpython.unsafe.tuple import tuple_setitem
 from numba.np.unsafe.ndarray import to_fixed_tuple
-from numba.typed import List, Dict
+from numba.typed import Dict
 
 from .barcode_bases import barcode_basis
 from ..gauss_mod_p import gauss_mod_p
@@ -349,15 +349,14 @@ def _reduce_single_dim(dim):
     len_tups_dim = dim + 1
     len_tups_next_dim = dim
     tuple_typ_next_dim = types.UniTuple(types.int64, len_tups_next_dim)
-    int64_list_typ = types.List(types.int64)
 
     @njit
     def _inner_reduce_single_dim(tups_dim, pos_idxs_to_clear,
                                  tups_next_dim=None):
         """R = MV"""
         # Initialize reduced matrix as the (cleared) boundary matrix
-        reduced = List.empty_list(int64_list_typ)
-        triangular = List.empty_list(int64_list_typ)
+        reduced = []
+        triangular = []
         if tups_next_dim is not None:
             spx2idx_next_dim = Dict.empty(tuple_typ_next_dim, types.int64)
             for j in range(len(tups_next_dim)):


### PR DESCRIPTION
A `numba`-accelerated algorithm computing the mod-2 reduction `R = DV` of a  boundary matrix `D`, and returning both `R` and `V` as well as the barcode.  Based upon the `gudhi` `SimplexTree` data structure.  Example usage:
```
import numpy as np
import gudhi
from permaviss.persistence_algebra.PH_classic import *

X = np.random.random((20, 2))

spxtree = gudhi.RipsComplex(X).create_simplex_tree(max_dimension=2)
filtr_by_dim = sort_filtration_by_dim(spxtree)
barcode = get_barcode(filtr_by_dim)  # Just the barcode
reduced_triangular = get_reduced_triangular(filtr_by_dim)  # The reduced and reducing matrices, dimension by dimension, in a sparse format
```

The "clearing" optimization from http://www.sci.utah.edu/~beiwang/teaching/cs6170-spring-2017/ChenKerber_2011.pdf is used.